### PR TITLE
fix: helm install and vdisk size

### DIFF
--- a/image-build/virt-customize/build.sh
+++ b/image-build/virt-customize/build.sh
@@ -23,7 +23,7 @@ CUSTOMIZED_UBUNTU_IMAGE=$OUTPUT_DIR/cluster-node.img
 # which will result in lots of zero writes and thus slow startup
 qemu-img convert -O raw $ORIGINAL_UBUNTU_IMAGE $CUSTOMIZED_UBUNTU_IMAGE
 # Give more space to OS to enable installing stuff
-qemu-img resize $CUSTOMIZED_UBUNTU_IMAGE +2.5G
+qemu-img resize $CUSTOMIZED_UBUNTU_IMAGE +5G
 
 # Customize the image
 virt-customize -v -x --commands-from-file commands -a "${CUSTOMIZED_UBUNTU_IMAGE}"

--- a/lab/container-images/redfish-lab/Dockerfile
+++ b/lab/container-images/redfish-lab/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update -y && \
         nginx \
         fcgiwrap \
         spawn-fcgi \
+        gpg \
         # ipmi console access
         ipmitool \
         freeipmi-tools \
@@ -79,11 +80,10 @@ PROMPT='\$(kube_ps1)'\$PROMPT" >> /root/.zshrc
 EOF
 
 RUN <<EOF
-curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | tee /usr/share/keyrings/helm.gpg > /dev/null
-apt-get install apt-transport-https --yes
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor -o /usr/share/keyrings/helm.gpg
+echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" > /etc/apt/sources.list.d/helm-stable-debian.list
 apt-get update
-apt-get install helm
+apt-get install -y --no-install-recommends helm
 EOF
 
 RUN mkdir -p /root/.kube


### PR DESCRIPTION
- updated helm apt url and removed redundant `apt-transport-https` package
- increase build image size as it was running out of space with the latest kernel and packages